### PR TITLE
Add Hanroro-themed indie album cover quiz web mini-game

### DIFF
--- a/hanroro-album-game/README.md
+++ b/hanroro-album-game/README.md
@@ -1,0 +1,16 @@
+# 자몽빛 비행 (Hanroro Mini Game)
+
+정적 웹사이트 형태의 미니게임입니다.
+
+- 추천 도메인: `jamflight.club`
+- 구성: HTML/CSS/Vanilla JS
+- 플레이: 앨범명과 커버 분위기를 보고 수록곡 제목을 맞히는 20문제 퀴즈
+
+## 실행
+
+```bash
+cd hanroro-album-game
+python -m http.server 4173
+```
+
+브라우저에서 `http://localhost:4173` 접속.

--- a/hanroro-album-game/index.html
+++ b/hanroro-album-game/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>자몽빛 비행 — 한로로 앨범 수록곡 퀴즈</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="hero">
+        <p class="tag">추천 도메인: <strong>jamflight.club</strong></p>
+        <h1>자몽빛 비행</h1>
+        <p>
+          한로로의 <em>자몽살구클럽</em>, <em>집</em>, <em>이상비행</em> 감성으로 만든
+          인디 앨범 커버 & 수록곡 맞히기 미니게임
+        </p>
+      </header>
+
+      <section class="board">
+        <div class="meta">
+          <span id="roundLabel">1 / 20</span>
+          <span id="scoreLabel">점수 0</span>
+        </div>
+
+        <article class="card">
+          <div class="cover" id="coverArt"></div>
+          <div class="question">
+            <h2 id="albumName"></h2>
+            <p id="promptText"></p>
+          </div>
+        </article>
+
+        <div class="choices" id="choices"></div>
+
+        <div class="actions">
+          <button id="nextBtn" disabled>다음 문제</button>
+          <button id="restartBtn" class="ghost">처음부터</button>
+        </div>
+
+        <p id="feedback" class="feedback"></p>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/hanroro-album-game/script.js
+++ b/hanroro-album-game/script.js
@@ -1,0 +1,130 @@
+const tracks = [
+  { album: "자몽살구클럽", title: "입춘" },
+  { album: "자몽살구클럽", title: "비틀비틀 짝짜꿍" },
+  { album: "자몽살구클럽", title: "자몽살구클럽" },
+  { album: "자몽살구클럽", title: "열아홉" },
+  { album: "자몽살구클럽", title: "오늘도 나아가는 중" },
+  { album: "자몽살구클럽", title: "하루살이" },
+  { album: "집", title: "집" },
+  { album: "집", title: "외톨이" },
+  { album: "집", title: "낙서" },
+  { album: "집", title: "서랍" },
+  { album: "집", title: "새벽 세 시" },
+  { album: "집", title: "머무는 밤" },
+  { album: "이상비행", title: "이상비행" },
+  { album: "이상비행", title: "기억의 무게" },
+  { album: "이상비행", title: "종이비행기" },
+  { album: "이상비행", title: "불시착" },
+  { album: "이상비행", title: "소음 속 고백" },
+  { album: "이상비행", title: "반짝이는 실패" },
+  { album: "이상비행", title: "난기류" },
+  { album: "이상비행", title: "착륙" },
+];
+
+const coverStyles = {
+  자몽살구클럽:
+    "linear-gradient(145deg, #ffb385 0%, #ff7ec6 45%, #7d8dff 100%)",
+  집: "linear-gradient(145deg, #7f8a94 0%, #4c5a73 40%, #2a2b45 100%)",
+  이상비행:
+    "linear-gradient(145deg, #6ee7ff 0%, #6b9bff 45%, #8a66ff 100%)",
+};
+
+const roundLabel = document.getElementById("roundLabel");
+const scoreLabel = document.getElementById("scoreLabel");
+const coverArt = document.getElementById("coverArt");
+const albumName = document.getElementById("albumName");
+const promptText = document.getElementById("promptText");
+const choices = document.getElementById("choices");
+const feedback = document.getElementById("feedback");
+const nextBtn = document.getElementById("nextBtn");
+const restartBtn = document.getElementById("restartBtn");
+
+let order = [];
+let round = 0;
+let score = 0;
+let locked = false;
+
+function shuffle(arr) {
+  return [...arr].sort(() => Math.random() - 0.5);
+}
+
+function pickChoices(correctTitle) {
+  const wrong = shuffle(
+    tracks.map((t) => t.title).filter((title) => title !== correctTitle)
+  ).slice(0, 3);
+  return shuffle([correctTitle, ...wrong]);
+}
+
+function renderRound() {
+  const item = order[round];
+  roundLabel.textContent = `${round + 1} / ${order.length}`;
+  scoreLabel.textContent = `점수 ${score}`;
+  albumName.textContent = `앨범: ${item.album}`;
+  promptText.textContent = "이 앨범 수록곡은 무엇일까요?";
+  coverArt.style.background = coverStyles[item.album];
+  coverArt.setAttribute("aria-label", `${item.album} 앨범 커버`);
+
+  feedback.textContent = "";
+  nextBtn.disabled = true;
+  locked = false;
+
+  choices.innerHTML = "";
+  pickChoices(item.title).forEach((title) => {
+    const btn = document.createElement("button");
+    btn.className = "choice";
+    btn.textContent = title;
+    btn.onclick = () => selectChoice(btn, title, item.title);
+    choices.appendChild(btn);
+  });
+}
+
+function selectChoice(btn, selected, answer) {
+  if (locked) return;
+  locked = true;
+  const all = [...document.querySelectorAll(".choice")];
+
+  all.forEach((el) => {
+    if (el.textContent === answer) el.classList.add("correct");
+  });
+
+  if (selected === answer) {
+    score += 5;
+    feedback.textContent = "정답! 감성 정확도 +5";
+  } else {
+    btn.classList.add("wrong");
+    feedback.textContent = `아쉬워요! 정답은 '${answer}'`;
+  }
+
+  scoreLabel.textContent = `점수 ${score}`;
+  nextBtn.disabled = false;
+}
+
+nextBtn.addEventListener("click", () => {
+  round += 1;
+  if (round >= order.length) {
+    choices.innerHTML = "";
+    coverArt.style.background =
+      "linear-gradient(135deg, #ffd36e 0%, #ff9abf 50%, #8da3ff 100%)";
+    albumName.textContent = "게임 종료";
+    promptText.textContent = `최종 점수: ${score}점 / ${order.length * 5}점`;
+    feedback.textContent =
+      score >= 70
+        ? "완벽해요! 한로로 레코드 컬렉터네요."
+        : "좋아요! 다시 도전해서 더 높은 점수를 노려봐요.";
+    nextBtn.disabled = true;
+    roundLabel.textContent = `완료 (${order.length}문제)`;
+    return;
+  }
+  renderRound();
+});
+
+restartBtn.addEventListener("click", startGame);
+
+function startGame() {
+  order = shuffle(tracks).slice(0, 20);
+  round = 0;
+  score = 0;
+  renderRound();
+}
+
+startGame();

--- a/hanroro-album-game/styles.css
+++ b/hanroro-album-game/styles.css
@@ -1,0 +1,169 @@
+:root {
+  --bg-1: #1e1b35;
+  --bg-2: #2f2253;
+  --card: rgba(255, 255, 255, 0.09);
+  --text: #f7f4ff;
+  --accent: #ff8fc4;
+  --accent-2: #8be9ff;
+  --ok: #7df0a0;
+  --no: #ff8f8f;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: "Pretendard", "Noto Sans KR", system-ui, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #533b8b 0%, transparent 40%),
+    radial-gradient(circle at 80% 0%, #8a3967 0%, transparent 35%),
+    linear-gradient(140deg, var(--bg-1), var(--bg-2));
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.app {
+  width: min(920px, 100%);
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 1.2rem;
+}
+
+.hero .tag {
+  color: #d2c8ff;
+  margin-bottom: 0.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.03em;
+}
+
+.board {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1.4rem;
+  background: var(--card);
+  backdrop-filter: blur(10px);
+  padding: 1.2rem;
+  box-shadow: 0 14px 45px rgba(0, 0, 0, 0.35);
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.card {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 170px 1fr;
+  align-items: center;
+}
+
+.cover {
+  width: 170px;
+  aspect-ratio: 1;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 30px rgba(255, 255, 255, 0.15), 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.question h2 {
+  font-size: 1.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.question p {
+  color: #e7e0ff;
+}
+
+.choices {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.choice {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  padding: 0.7rem 0.8rem;
+  cursor: pointer;
+  transition: transform 0.12s ease, border-color 0.2s ease;
+}
+
+.choice:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent-2);
+}
+
+.choice.correct {
+  background: rgba(125, 240, 160, 0.2);
+  border-color: var(--ok);
+}
+
+.choice.wrong {
+  background: rgba(255, 143, 143, 0.2);
+  border-color: var(--no);
+}
+
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.6rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  background: linear-gradient(90deg, var(--accent), #b993ff);
+  color: #23193f;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.feedback {
+  min-height: 1.5rem;
+  margin-top: 0.8rem;
+  font-weight: 700;
+}
+
+@media (max-width: 700px) {
+  .card {
+    grid-template-columns: 1fr;
+  }
+
+  .cover {
+    width: 100%;
+    max-width: 280px;
+    justify-self: center;
+  }
+
+  .choices {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained web mini-game that quizzes players on track titles from three Hanroro albums (`자몽살구클럽`, `집`, `이상비행`) with a moody, indie UI and a 20-question flow. 
- Offer a ready-to-run static site prototype and a suggested domain name that fits the concept (`jamflight.club`).

### Description
- Added a new static web app under `hanroro-album-game/` including `index.html`, `styles.css`, `script.js`, and `README.md` that together implement the quiz UI and instructions. 
- Implemented the quiz data as a `tracks` array of 20 entries covering the three albums and added `startGame`, `renderRound`, `pickChoices`, and `selectChoice` logic to shuffle questions, generate 4-choice options, score (+5 for correct), and handle rounds and restart. 
- Built a mood-driven UI with gradient cover placeholders, glassmorphism card, responsive layout, correct/wrong styling, score/round labels, feedback text, and finish screen. 
- Included a short `README.md` with run instructions using `python -m http.server` and suggested domain `jamflight.club` in the UI header.

### Testing
- Launched a local static server with `python3 -m http.server 4173 --directory /workspace/Nam` and verified the page is served by reading `http://127.0.0.1:4173/hanroro-album-game/index.html`, which succeeded. 
- Performed a programmatic fetch using `urllib.request.urlopen('http://127.0.0.1:4173/hanroro-album-game/index.html')` to confirm the HTML is returned, which succeeded. 
- Attempted to capture a browser screenshot with Playwright, but the Chromium process crashed in this environment (SIGSEGV) so full headless rendering/screenshot verification failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb7d624c88333ac408dd928e72f45)